### PR TITLE
Replace `System.Object` with `UnityEngine.Object` in `Editor.Button.Draw`

### DIFF
--- a/Assets/EasyButtons/Editor/Button.cs
+++ b/Assets/EasyButtons/Editor/Button.cs
@@ -4,6 +4,7 @@
     using JetBrains.Annotations;
     using UnityEditor;
     using Utils;
+    using UnityEngine;
 
     /// <summary>
     /// A class that holds information about a button and can draw it in the inspector.
@@ -36,7 +37,7 @@
             _disabled = ! (buttonAttribute.Mode == ButtonMode.AlwaysEnabled || inAppropriateMode);
         }
 
-        public void Draw(object[] targets)
+        public void Draw(Object[] targets)
         {
             using (new EditorGUI.DisabledScope(_disabled))
             {
@@ -63,6 +64,6 @@
             }
         }
 
-        protected abstract void DrawInternal(object[] targets);
+        protected abstract void DrawInternal(Object[] targets);
     }
 }

--- a/Assets/EasyButtons/Editor/ButtonWithParams.cs
+++ b/Assets/EasyButtons/Editor/ButtonWithParams.cs
@@ -20,7 +20,7 @@
             _expanded = buttonAttribute.Expanded;
         }
 
-        protected override void DrawInternal(object[] targets)
+        protected override void DrawInternal(Object[] targets)
         {
             (Rect foldoutRect, Rect buttonRect) = DrawUtility.GetFoldoutAndButtonRects(DisplayName);
 

--- a/Assets/EasyButtons/Editor/ButtonWithoutParams.cs
+++ b/Assets/EasyButtons/Editor/ButtonWithoutParams.cs
@@ -8,7 +8,7 @@
         public ButtonWithoutParams(MethodInfo method, ButtonAttribute buttonAttribute)
             : base(method, buttonAttribute) { }
 
-        protected override void DrawInternal(object[] targets)
+        protected override void DrawInternal(Object[] targets)
         {
             if ( ! GUILayout.Button(DisplayName))
                 return;

--- a/Assets/EasyButtons/Editor/ButtonsDrawer.cs
+++ b/Assets/EasyButtons/Editor/ButtonsDrawer.cs
@@ -13,7 +13,8 @@
         /// <summary>
         /// A list of buttons that can be drawn for the class.
         /// </summary>
-        [PublicAPI] public readonly List<Button> Buttons = new List<Button>();
+        [PublicAPI]
+        public readonly List<Button> Buttons = new List<Button>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ButtonsDrawer"/> class and fills <see cref="Buttons"/> with
@@ -23,8 +24,7 @@
         /// <param name="target">Editor's target.</param>
         public ButtonsDrawer(Object target)
         {
-            const BindingFlags flags = BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public |
-                                       BindingFlags.NonPublic;
+            const BindingFlags flags = BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic;
             var methods = target.GetType().GetMethods(flags);
 
             foreach (MethodInfo method in methods)

--- a/Assets/EasyButtons/Editor/ButtonsDrawer.cs
+++ b/Assets/EasyButtons/Editor/ButtonsDrawer.cs
@@ -13,8 +13,7 @@
         /// <summary>
         /// A list of buttons that can be drawn for the class.
         /// </summary>
-        [PublicAPI]
-        public readonly List<Button> Buttons = new List<Button>();
+        [PublicAPI] public readonly List<Button> Buttons = new List<Button>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ButtonsDrawer"/> class and fills <see cref="Buttons"/> with
@@ -22,9 +21,10 @@
         /// performance of the custom editor.
         /// </summary>
         /// <param name="target">Editor's target.</param>
-        public ButtonsDrawer(object target)
+        public ButtonsDrawer(Object target)
         {
-            const BindingFlags flags = BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic;
+            const BindingFlags flags = BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public |
+                                       BindingFlags.NonPublic;
             var methods = target.GetType().GetMethods(flags);
 
             foreach (MethodInfo method in methods)

--- a/Assets/EasyButtons/Editor/ButtonsDrawer.cs
+++ b/Assets/EasyButtons/Editor/ButtonsDrawer.cs
@@ -3,6 +3,7 @@
     using System.Collections.Generic;
     using System.Reflection;
     using JetBrains.Annotations;
+    using UnityEngine;
 
     /// <summary>
     /// Helper class that can be used in custom Editors to draw methods marked with the <see cref="ButtonAttribute"/> as buttons.
@@ -40,7 +41,7 @@
         /// <summary>
         /// Draws all the methods marked with <see cref="ButtonAttribute"/>.
         /// </summary>
-        public void DrawButtons(object[] targets)
+        public void DrawButtons(Object[] targets)
         {
             foreach (Button button in Buttons)
             {


### PR DESCRIPTION
The type of [`Editor.targets`](https://docs.unity3d.com/ScriptReference/Editor-targets.html) is `UnityEngine.Object[]`, not `System.Object[]`. Attempting to implicitly convert `Object[]` to `object[]` causes Rider to complain (and it's not great practice anyway).

The alternative to this PR is what I'm currently doing in my code, which I'd rather not:
```cs
public override void OnInspectorGUI()
{
	DrawDefaultInspector();
	var objects = Array.ConvertAll(targets, item => (object) item);
	_buttonsDrawer.DrawButtons(objects);
}
```