### PR TITLE
Replace `object[]` with `IEnumerable<object>`

### DIFF
--- a/Assets/EasyButtons/Editor/Button.cs
+++ b/Assets/EasyButtons/Editor/Button.cs
@@ -4,6 +4,7 @@
     using JetBrains.Annotations;
     using UnityEditor;
     using Utils;
+    using System.Collections.Generic;
 
     /// <summary>
     /// A class that holds information about a button and can draw it in the inspector.
@@ -36,7 +37,7 @@
             _disabled = ! (buttonAttribute.Mode == ButtonMode.AlwaysEnabled || inAppropriateMode);
         }
 
-        public void Draw(object[] targets)
+        public void Draw(IEnumerable<object> targets)
         {
             using (new EditorGUI.DisabledScope(_disabled))
             {
@@ -63,6 +64,6 @@
             }
         }
 
-        protected abstract void DrawInternal(object[] targets);
+        protected abstract void DrawInternal(IEnumerable<object> targets);
     }
 }

--- a/Assets/EasyButtons/Editor/ButtonWithParams.cs
+++ b/Assets/EasyButtons/Editor/ButtonWithParams.cs
@@ -7,6 +7,7 @@
     using UnityEngine;
     using Utils;
     using Object = UnityEngine.Object;
+    using System.Collections.Generic;
 
     internal class ButtonWithParams : Button
     {
@@ -20,7 +21,7 @@
             _expanded = buttonAttribute.Expanded;
         }
 
-        protected override void DrawInternal(object[] targets)
+        protected override void DrawInternal(IEnumerable<object> targets)
         {
             (Rect foldoutRect, Rect buttonRect) = DrawUtility.GetFoldoutAndButtonRects(DisplayName);
 

--- a/Assets/EasyButtons/Editor/ButtonWithoutParams.cs
+++ b/Assets/EasyButtons/Editor/ButtonWithoutParams.cs
@@ -2,13 +2,14 @@
 {
     using System.Reflection;
     using UnityEngine;
+    using System.Collections.Generic;
 
     internal class ButtonWithoutParams : Button
     {
         public ButtonWithoutParams(MethodInfo method, ButtonAttribute buttonAttribute)
             : base(method, buttonAttribute) { }
 
-        protected override void DrawInternal(object[] targets)
+        protected override void DrawInternal(IEnumerable<object> targets)
         {
             if ( ! GUILayout.Button(DisplayName))
                 return;

--- a/Assets/EasyButtons/Editor/ButtonsDrawer.cs
+++ b/Assets/EasyButtons/Editor/ButtonsDrawer.cs
@@ -40,7 +40,7 @@
         /// <summary>
         /// Draws all the methods marked with <see cref="ButtonAttribute"/>.
         /// </summary>
-        public void DrawButtons(object[] targets)
+        public void DrawButtons(IEnumerable<object> targets)
         {
             foreach (Button button in Buttons)
             {


### PR DESCRIPTION
Implements the changes suggested by https://github.com/madsbangh/EasyButtons/pull/21#issuecomment-860633858.

Supersedes #21.