### PR TITLE
Support async method

### DIFF
--- a/Assets/EasyButtons/Editor/Button.cs
+++ b/Assets/EasyButtons/Editor/Button.cs
@@ -5,6 +5,7 @@
     using UnityEditor;
     using Utils;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// A class that holds information about a button and can draw it in the inspector.
@@ -53,14 +54,21 @@
         internal static Button Create(MethodInfo method, ButtonAttribute buttonAttribute)
         {
             var parameters = method.GetParameters();
-
             if (parameters.Length == 0)
             {
-                return new ButtonWithoutParams(method, buttonAttribute);
+                if (method.ReturnType != typeof(Task)) {
+                    return new ButtonWithoutParams(method, buttonAttribute);
+                } else {
+                    return new ButtonWithoutParamsAsync(method, buttonAttribute);
+                }
             }
             else
             {
-                return new ButtonWithParams(method, buttonAttribute, parameters);
+                if (method.ReturnType != typeof(Task)) {
+                    return new ButtonWithParams(method, buttonAttribute, parameters);
+                } else {
+                    return new ButtonWithParamsAsync(method, buttonAttribute, parameters);
+                }
             }
         }
 

--- a/Assets/EasyButtons/Editor/ButtonWithParams.cs
+++ b/Assets/EasyButtons/Editor/ButtonWithParams.cs
@@ -11,8 +11,8 @@
 
     internal class ButtonWithParams : Button
     {
-        private readonly Parameter[] _parameters;
-        private bool _expanded;
+        protected readonly Parameter[] _parameters;
+        protected bool _expanded;
 
         public ButtonWithParams(MethodInfo method, ButtonAttribute buttonAttribute, ParameterInfo[] parameters)
             : base(method, buttonAttribute)
@@ -44,7 +44,7 @@
             }
         }
 
-        private readonly struct Parameter
+        protected readonly struct Parameter
         {
             private readonly FieldInfo _fieldInfo;
             private readonly ScriptableObject _scriptableObj;

--- a/Assets/EasyButtons/Editor/ButtonWithParams.cs
+++ b/Assets/EasyButtons/Editor/ButtonWithParams.cs
@@ -12,7 +12,7 @@
     internal class ButtonWithParams : Button
     {
         protected readonly Parameter[] _parameters;
-        protected bool _expanded;
+        private bool _expanded;
 
         public ButtonWithParams(MethodInfo method, ButtonAttribute buttonAttribute, ParameterInfo[] parameters)
             : base(method, buttonAttribute)
@@ -36,10 +36,13 @@
             if ( ! GUI.Button(buttonRect, "Invoke"))
                 return;
 
+            InvokeMethod(targets);
+        }
+
+        protected virtual void InvokeMethod(IEnumerable<object> targets) {
             var paramValues = _parameters.Select(param => param.Value).ToArray();
 
-            foreach (object obj in targets)
-            {
+            foreach (object obj in targets) {
                 Method.Invoke(obj, paramValues);
             }
         }

--- a/Assets/EasyButtons/Editor/ButtonWithParamsAsync.cs
+++ b/Assets/EasyButtons/Editor/ButtonWithParamsAsync.cs
@@ -3,8 +3,6 @@
     using System.Linq;
     using System.Reflection;
     using UnityEditor;
-    using UnityEngine;
-    using Utils;
     using System.Collections.Generic;
     using System.Threading.Tasks;
 
@@ -13,25 +11,10 @@
         public ButtonWithParamsAsync(MethodInfo method, ButtonAttribute buttonAttribute, ParameterInfo[] parameters)
             : base(method, buttonAttribute, parameters) { }
 
-        protected async override void DrawInternal(IEnumerable<object> targets)
-        {
-            (Rect foldoutRect, Rect buttonRect) = DrawUtility.GetFoldoutAndButtonRects(DisplayName);
-
-            _expanded = DrawUtility.DrawInFoldout(foldoutRect, _expanded, DisplayName, () =>
-            {
-                foreach (Parameter param in _parameters)
-                {
-                    param.Draw();
-                }
-            });
-
-            if ( ! GUI.Button(buttonRect, "Invoke"))
-                return;
-
+        protected async override void InvokeMethod(IEnumerable<object> targets) {
             var paramValues = _parameters.Select(param => param.Value).ToArray();
 
-            foreach (object obj in targets)
-            {
+            foreach (object obj in targets) {
                 Task task = (Task)Method.Invoke(obj, paramValues);
                 await task;
             }

--- a/Assets/EasyButtons/Editor/ButtonWithParamsAsync.cs
+++ b/Assets/EasyButtons/Editor/ButtonWithParamsAsync.cs
@@ -1,0 +1,40 @@
+﻿namespace EasyButtons.Editor
+{
+    using System.Linq;
+    using System.Reflection;
+    using UnityEditor;
+    using UnityEngine;
+    using Utils;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+
+    internal class ButtonWithParamsAsync : ButtonWithParams
+    {
+        public ButtonWithParamsAsync(MethodInfo method, ButtonAttribute buttonAttribute, ParameterInfo[] parameters)
+            : base(method, buttonAttribute, parameters) { }
+
+        protected async override void DrawInternal(IEnumerable<object> targets)
+        {
+            (Rect foldoutRect, Rect buttonRect) = DrawUtility.GetFoldoutAndButtonRects(DisplayName);
+
+            _expanded = DrawUtility.DrawInFoldout(foldoutRect, _expanded, DisplayName, () =>
+            {
+                foreach (Parameter param in _parameters)
+                {
+                    param.Draw();
+                }
+            });
+
+            if ( ! GUI.Button(buttonRect, "Invoke"))
+                return;
+
+            var paramValues = _parameters.Select(param => param.Value).ToArray();
+
+            foreach (object obj in targets)
+            {
+                Task task = (Task)Method.Invoke(obj, paramValues);
+                await task;
+            }
+        }
+    }
+}

--- a/Assets/EasyButtons/Editor/ButtonWithParamsAsync.cs.meta
+++ b/Assets/EasyButtons/Editor/ButtonWithParamsAsync.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 5a48d172e2547fc4c933854b911246ab
+timeCreated: 1607331593

--- a/Assets/EasyButtons/Editor/ButtonWithoutParams.cs
+++ b/Assets/EasyButtons/Editor/ButtonWithoutParams.cs
@@ -14,8 +14,12 @@
             if ( ! GUILayout.Button(DisplayName))
                 return;
 
-            foreach (object obj in targets)
-            {
+            InvokeMethod(targets);
+        }
+
+        protected virtual void InvokeMethod(IEnumerable<object> targets)
+        {
+            foreach (object obj in targets) {
                 Method.Invoke(obj, null);
             }
         }

--- a/Assets/EasyButtons/Editor/ButtonWithoutParamsAsync.cs
+++ b/Assets/EasyButtons/Editor/ButtonWithoutParamsAsync.cs
@@ -1,0 +1,25 @@
+namespace EasyButtons.Editor
+{
+    using System.Reflection;
+    using UnityEngine;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+
+    internal class ButtonWithoutParamsAsync : ButtonWithoutParams
+    {
+        public ButtonWithoutParamsAsync(MethodInfo method, ButtonAttribute buttonAttribute)
+            : base(method, buttonAttribute) { }
+
+        protected async override void DrawInternal(IEnumerable<object> targets)
+        {
+            if ( ! GUILayout.Button(DisplayName))
+                return;
+
+            foreach (object obj in targets)
+            {
+                Task task = (Task)Method.Invoke(obj, null);
+                await task;
+            }
+        }
+    }
+}

--- a/Assets/EasyButtons/Editor/ButtonWithoutParamsAsync.cs
+++ b/Assets/EasyButtons/Editor/ButtonWithoutParamsAsync.cs
@@ -1,7 +1,6 @@
 namespace EasyButtons.Editor
 {
     using System.Reflection;
-    using UnityEngine;
     using System.Collections.Generic;
     using System.Threading.Tasks;
 
@@ -10,13 +9,9 @@ namespace EasyButtons.Editor
         public ButtonWithoutParamsAsync(MethodInfo method, ButtonAttribute buttonAttribute)
             : base(method, buttonAttribute) { }
 
-        protected async override void DrawInternal(IEnumerable<object> targets)
+        protected async override void InvokeMethod(IEnumerable<object> targets)
         {
-            if ( ! GUILayout.Button(DisplayName))
-                return;
-
-            foreach (object obj in targets)
-            {
+            foreach (object obj in targets) {
                 Task task = (Task)Method.Invoke(obj, null);
                 await task;
             }

--- a/Assets/EasyButtons/Editor/ButtonWithoutParamsAsync.cs.meta
+++ b/Assets/EasyButtons/Editor/ButtonWithoutParamsAsync.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b250c1fbffc14964fb80e3bfd5be3643
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Problem
I used EasyButton on an async method that I invoked in edit mode. The method was supposed to throw an exception, but I did not see it in the console. That is because the method was not awaited, so the exception was lost.

### Solution
Added async subclasses that await the task after invoking the method. Async method are detected by checking that they return a Task.