### PR TITLE
feat: handle nullable of serializable types

### DIFF
--- a/Assets/EasyButtons/Editor/Utils/ScriptableObjectCache.cs
+++ b/Assets/EasyButtons/Editor/Utils/ScriptableObjectCache.cs
@@ -32,11 +32,9 @@
 
             if (_classDict.TryGetValue(className, out Type classType))
                 return classType;
-
-            if (!fieldType.IsUnitySerializable())
-            {
+            
+            if (!fieldType.IsUnitySerializable() && !fieldType.IsNullableOfUnitySerializable(out fieldType)) 
                 fieldType = typeof(NonSerializedError);
-            }
 
             classType = CreateClass(className, fieldName, fieldType, hasDefaultValue, defaultValue);
             _classDict[className] = classType;

--- a/Assets/EasyButtons/Editor/Utils/TypeExtensions.cs
+++ b/Assets/EasyButtons/Editor/Utils/TypeExtensions.cs
@@ -49,6 +49,38 @@
             return _unitySerializablePrimitiveTypes.Contains(type) || _unitySerializableBuiltinTypes.Contains(type);
         }
         
+        /// <summary>
+        /// Checks if the type is a nullable type with a Unity-serializable type as a generic argument.
+        /// </summary>
+        /// <param name="type">The type to check.</param>
+        /// <param name="genericArgument">The generic argument of the nullable type. Set to NonSerializedError if the method returns false.</param>
+        /// <example><code>
+        /// Type nullableIntType = typeof(int?);
+        /// bool isNullableOfUnitySerializable = nullableIntType.IsNullableOfUnitySerializable(out Type genericArgument);
+        /// Debug.Log(isNullableOfUnitySerializable); // true
+        /// Debug.Log(genericArgument); // System.Int32
+        /// </code></example>
+        /// <returns></returns>
+        public static bool IsNullableOfUnitySerializable(this Type type, out Type genericArgument)
+        {
+            genericArgument = typeof(NonSerializedError);
+            
+            if (!type.IsGenericType)
+                return false;
+
+            Type genericType = type.GetGenericTypeDefinition();
+            if (genericType != typeof(Nullable<>))
+                return false;
+
+            Type[] genericArguments = type.GetGenericArguments();
+            if (!genericArguments[0].IsUnitySerializable()) 
+                return false;
+            
+            genericArgument = genericArguments[0];
+            return true;
+
+        }
+        
         /// <summary>Checks if the type is a primitive type serializable by Unity.</summary>
         /// <param name="type">The type to check.</param>
         /// <returns><see langword="true"/> if the type is a primitive type that can be serialized by Unity.</returns>


### PR DESCRIPTION
A small modification to handle nullables of already supported types.

```csharp
using EasyButtons;
using UnityEngine;

public class NullableTest : MonoBehaviour
{
    [Button]
    private void Run(int intNoDefault, int? intNullableNoDefault, int intDefault = 3, int? intNullableDefault = 4)
    {
        Debug.Log($"{intNoDefault} {intNullableNoDefault} {intDefault} {intNullableDefault}");   
    }
}
```

![obraz](https://github.com/madsbangh/EasyButtons/assets/49511937/1ce527f2-cedc-440a-8716-91148888420d)
![obraz](https://github.com/madsbangh/EasyButtons/assets/49511937/0ea19460-0510-4215-b710-6cb88f58cd98)

Works by getting the generic arg out of the nullable and then continues with the current flow.